### PR TITLE
feat(ci): add linux/arm64 platform to Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,6 +51,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Adds `platforms: linux/amd64,linux/arm64` to the `docker/build-push-action` step in `docker-publish.yml`
- The published GHCR image will include a multi-arch manifest, allowing ARM hosts (Apple Silicon, AWS Graviton, etc.) to pull the correct native layer automatically

## Changes

One line added to [`.github/workflows/docker-publish.yml`](.github/workflows/docker-publish.yml):

```yaml
platforms: linux/amd64,linux/arm64
```

No `Dockerfile` changes needed — `ghcr.io/hugomods/hugo:base` already ships an `arm64` layer, and `docker/setup-buildx-action` was already present in the workflow.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)