### PR TITLE
Add automated dead-link detection via GitHub Actions

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,36 @@
+name: Link Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "latest"
+          extended: true
+
+      - name: Install lychee
+        run: |
+          curl -sSfL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+
+      - name: Build site
+        run: hugo --gc --minify
+
+      - name: Check links
+        continue-on-error: true
+        run: lychee --config .lychee.toml --root-dir ./public ./public

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,37 @@
+# lychee link checker configuration
+# https://lychee.cli.rs/usage/config/
+
+# Check both internal and external links
+include_mail = false
+
+# Timeout per request (seconds)
+timeout = 30
+
+# Max concurrent requests
+max_concurrency = 8
+
+# Accept these status codes as valid
+accept = [200, 204, 206, 301, 302, 307, 308, 429]
+
+# Exclude patterns (adjust as needed)
+exclude = [
+  # Favicon/icon assets referenced by PaperMod theme but not present on the
+  # live site — these are browser-requested resources, not content links
+  "^https://samantha\\.wiki/(apple-touch-icon\\.png|favicon(-(16x16|32x32))?\\.png|favicon\\.ico|safari-pinned-tab\\.svg)$",
+  # Localhost / dev-only links
+  "^http://localhost",
+  "^http://127\\.0\\.0\\.1",
+  # mailto links
+  "^mailto:",
+  # Sites that block automated requests (403/429)
+  "linkedin\\.com",
+  "scholar\\.google\\.com",
+  "journals\\.aps\\.org",
+  "reddit\\.com",
+  "instagram\\.com",
+  "tandfonline\\.com",
+]
+
+# Skip private/internal IPs
+exclude_private = true
+exclude_loopback = true


### PR DESCRIPTION
## Summary

- Adds a **lychee**-based link checker workflow (`.github/workflows/link-check.yml`) that builds the Hugo site and scans all output HTML for broken links
- Adds `.lychee.toml` config to tune exclusions and request behavior
- Runs on push to `main` and on PRs
- Reports dead links via `continue-on-error` — flags without blocking merges

## Tool choice

**lychee** was selected over alternatives (linkinator, broken-link-checker) because it is:
- Fast — written in Rust with async I/O
- Well-maintained and widely used
- Highly configurable via `.lychee.toml`

**Note:** The lychee CLI is installed directly rather than using `lychee-action@v2`, which was found to silently fail to detect dead links when scanning directories (reporting ~347 total links vs the actual ~1300).

## How it works

1. Checks out the repo with submodules
2. Installs Hugo and builds the site (`hugo --gc --minify`)
3. Installs lychee from GitHub releases
4. Runs lychee against `./public` with `--root-dir ./public` to resolve root-relative links locally
5. Exits non-zero on dead links, but `continue-on-error: true` prevents merge blocking

## Exclusions

- Favicon/icon assets (PaperMod theme references, not on live site)
- Sites that block automated requests: LinkedIn, Google Scholar, APS journals, Reddit, Instagram, Taylor & Francis
- 429 (rate limiting) accepted as valid
- Private/loopback IPs, localhost, mailto links

## Test plan

- [x] Verified workflow runs successfully on this PR
- [x] Confirmed dead links are detected (tested with `https://www.404s.design/asdf` and `https://google.com/asdf`)
- [x] Confirmed dead links produce warnings via `continue-on-error`, not hard failures

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)