### PR TITLE
Fix author rendering as map[name:Samantha Barron]

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -93,8 +93,7 @@ params:
   showtoc: false
   tocopen: false
 
-  author:
-    name: Samantha Barron
+  author: Samantha Barron
 
   fuseOpts:
     isCaseSensitive: false


### PR DESCRIPTION
## Summary
- Fixed `map[name:Samantha Barron]` appearing in page metadata, HTML meta tags, and JSON-LD structured data
- **Root cause**: `params.author` in `hugo.yaml` was defined as a map (`{name: Samantha Barron}`) but PaperMod templates expect a plain string
- Changed from nested map to flat string value

Closes #10

## Test plan
- [x] Docker build succeeds
- [x] Built site output contains no `map[name:` occurrences
- [ ] Verify author displays correctly on https://samantha.wiki/now/ after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)