### PR TITLE
Gate image build on all checks passing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,17 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  smoke-test:
+    uses: ./.github/workflows/docker-test.yml
+  markdown-lint:
+    uses: ./.github/workflows/markdown-lint.yml
+  proselint:
+    uses: ./.github/workflows/proselint.yml
+  link-check:
+    uses: ./.github/workflows/link-check.yml
+
   build:
+    needs: [smoke-test, markdown-lint, proselint, link-check]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 jobs:
   smoke-test:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 jobs:
   link-check:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/proselint.yml
+++ b/.github/workflows/proselint.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 jobs:
   proselint:


### PR DESCRIPTION
## Summary
- Adds `workflow_call` trigger to all check workflows (smoke test, markdown lint, proselint, link check) so they can be called as reusable workflows
- Updates `docker-publish.yml` to call those check workflows as prerequisite jobs
- The `build` job now uses `needs:` to require all checks to pass before building/pushing the image

Closes the "Images shouldn't build without all other checks passing" issue.

## Test plan
- [ ] Verify the `Build and Push Docker Image` workflow runs all four check jobs before the `build` job
- [ ] Verify a failing check (e.g. markdown lint) blocks the image build
- [ ] Verify the standalone check workflows still trigger independently on push/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)