### PR TITLE
Switch color palette to Catppuccin

### DIFF
--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -1,0 +1,40 @@
+:root {
+    --gap: 24px;
+    --content-gap: 20px;
+    --nav-width: 1024px;
+    --main-width: 720px;
+    --header-height: 60px;
+    --footer-height: 60px;
+    --radius: 8px;
+    --theme: rgb(239, 241, 245);
+    --entry: rgb(230, 233, 239);
+    --primary: rgb(76, 79, 105);
+    --secondary: rgb(108, 111, 133);
+    --tertiary: rgb(172, 176, 190);
+    --content: rgb(76, 79, 105);
+    --code-block-bg: rgb(30, 30, 46);
+    --code-bg: rgb(220, 224, 232);
+    --border: rgb(204, 208, 218);
+    color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+    --theme: rgb(30, 30, 46);
+    --entry: rgb(49, 50, 68);
+    --primary: rgb(205, 214, 244);
+    --secondary: rgb(166, 173, 200);
+    --tertiary: rgb(69, 71, 90);
+    --content: rgb(186, 194, 222);
+    --code-block-bg: rgb(24, 24, 37);
+    --code-bg: rgb(49, 50, 68);
+    --border: rgb(49, 50, 68);
+    color-scheme: dark;
+}
+
+.list {
+    background: var(--code-bg);
+}
+
+[data-theme="dark"] .list {
+    background: var(--theme);
+}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -47,6 +47,9 @@ menu:
       weight: 20
 
 params:
+  assets:
+    theme_color: "#1e1e2e"
+    msapplication_TileColor: "#1e1e2e"
   profileMode:
     enabled: true
     title: "Hi there!"


### PR DESCRIPTION
## Summary
- Override PaperMod default colors with the [Catppuccin](https://catppuccin.com/) palette
- Light theme uses **Catppuccin Latte**, dark theme uses **Catppuccin Mocha**
- Uses Hugo's asset override (`assets/css/core/theme-vars.css`) rather than modifying the PaperMod submodule
- Sets meta theme-color to Mocha base (`#1e1e2e`) via `hugo.yaml`

## Color mapping

| Variable | Light (Latte) | Dark (Mocha) |
|---|---|---|
| `--theme` | Base | Base |
| `--entry` | Mantle | Surface0 |
| `--primary` | Text | Text |
| `--secondary` | Subtext0 | Subtext0 |
| `--tertiary` | Surface2 | Surface1 |
| `--content` | Text | Subtext1 |
| `--code-block-bg` | Mocha Base | Mantle |
| `--code-bg` | Crust | Surface0 |
| `--border` | Surface0 | Surface0 |

## Test plan
- [ ] Verify light mode appearance
- [ ] Verify dark mode appearance
- [ ] Toggle between light/dark and confirm smooth transition
- [ ] Check code blocks are readable in both modes
- [ ] Verify system preference detection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)