### PR TITLE
Show project summary as subtitle on single pages

### DIFF
--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,3 +1,11 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
       integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw=="
       crossorigin="anonymous" referrerpolicy="no-referrer" />
+<style>
+  .post-subtitle {
+    margin-top: 0.25em;
+    font-size: 1.1em;
+    color: var(--secondary);
+    font-style: italic;
+  }
+</style>

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -14,6 +14,9 @@
       </span>
       {{- end }}
     </h1>
+    {{- with .Params.summary }}
+    <p class="post-subtitle">{{ . }}</p>
+    {{- end }}
     {{- if .Description }}
     <div class="post-description">
       {{ .Description }}


### PR DESCRIPTION
## Summary
- Display the frontmatter `summary` field as an italic subtitle beneath the project title and above the link buttons on single project pages
- The project list page already renders summaries via Hugo's `.Summary` variable, so no changes needed there
- Added `.post-subtitle` styling (italic, secondary color) in `extend_head.html`

## Test plan
- [ ] Verify summaries appear on the projects list page
- [ ] Verify subtitles appear on individual project pages (e.g. ClamNet, QR Code Tattoo, ad-begone)
- [ ] Confirm subtitle renders above the link buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)