### PR TITLE
Generalize transparent-background image effect site-wide

### DIFF
--- a/assets/css/extended/images.css
+++ b/assets/css/extended/images.css
@@ -1,0 +1,13 @@
+/* Global transparent-white-background effect for all images.
+   Light: multiply blend makes white pixels invisible against the background.
+   Dark: invert + hue-rotate preserves original colors, screen blend makes
+         black (formerly white) pixels invisible. */
+
+img {
+    mix-blend-mode: multiply;
+}
+
+[data-theme="dark"] img {
+    filter: invert(1) hue-rotate(180deg);
+    mix-blend-mode: screen;
+}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -60,12 +60,6 @@
     max-height: 100%;
     border-radius: var(--radius);
     object-fit: contain;
-    mix-blend-mode: multiply;
-  }
-
-  [data-theme="dark"] .home-paper .paper-thumb img {
-    filter: invert(1) hue-rotate(180deg);
-    mix-blend-mode: screen;
   }
 
   .home-paper .paper-details {

--- a/layouts/papers/list.html
+++ b/layouts/papers/list.html
@@ -22,12 +22,6 @@
     max-height: 100%;
     border-radius: var(--radius);
     object-fit: contain;
-    mix-blend-mode: multiply;
-  }
-
-  [data-theme="dark"] .paper-entry .paper-thumb img {
-    filter: invert(1) hue-rotate(180deg);
-    mix-blend-mode: screen;
   }
 
   .paper-entry .paper-details {


### PR DESCRIPTION
## Summary
- Moved the `mix-blend-mode` / `filter: invert` rules from paper-specific inline `<style>` blocks to a new global CSS file (`assets/css/extended/images.css`)
- All images on the site now get the transparent-white-background treatment in both light and dark mode (previously only paper thumbnails had it)
- Removed duplicate rules from `layouts/index.html` and `layouts/papers/list.html`

## Test plan
- [ ] Verify paper thumbnails still render correctly (light & dark mode)
- [ ] Verify project thumbnails now have the transparent background effect
- [ ] Verify images in post/page content also get the effect
- [ ] Confirm Hugo builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)